### PR TITLE
Remove unnecessary `datasets` import

### DIFF
--- a/transcribe_demo.py
+++ b/transcribe_demo.py
@@ -11,7 +11,6 @@ from pythonosc import udp_client
 
 import torch
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, AutoTokenizer, AutoModelForSeq2SeqLM, pipeline
-from datasets import load_dataset
 
 device = "cuda:0" if torch.cuda.is_available() else "cpu"
 torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32


### PR DESCRIPTION
This import isn't actually used for anything, but it still blocks you from running the script if you don't have it installed, as it's not listed in the requirements.

To fix, remove the line that imports `load_dataset` from `datasets`.